### PR TITLE
Improve Persian popup for آ

### DIFF
--- a/app/src/main/assets/ime/text/characters/extended_popups/fa.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/fa.json
@@ -14,10 +14,10 @@
       "ا": {
         "relevant": [
           { "code": 1649, "label": "ٱ" },
-          { "code": 1570, "label": "آ" },
           { "code": 1569, "label": "ء" },
           { "code": 1571, "label": "أ" },
-          { "code": 1573, "label": "إ" }
+          { "code": 1573, "label": "إ" },
+          { "code": 1570, "label": "آ" }
         ]
       },
       "ه": {


### PR DESCRIPTION
With this rearrange, when Accent is prioritized in hinted symbols, آ is the first option in the popup.
آ is one of the most used alphabets in Persian language.